### PR TITLE
support multiple access token cookie names

### DIFF
--- a/deploy/platform-reports/templates/grafana-proxy-deployment.yaml
+++ b/deploy/platform-reports/templates/grafana-proxy-deployment.yaml
@@ -42,8 +42,8 @@ spec:
                 secretKeyRef:
                   name: platformservices-secret
                   key: cluster_token
-            - name: NP_AUTH_ACCESS_TOKEN_COOKIE_NAME
-              value: {{ .Values.platform.accessTokenCookieName }}
+            - name: NP_AUTH_ACCESS_TOKEN_COOKIE_NAMES
+              value: {{ .Values.platform.accessTokenCookieNames }}
             - name: NP_API_URL
               value: {{ .Values.platform.apiUrl }}
           {{- if .Values.grafanaProxy.resources }}

--- a/deploy/platform-reports/templates/prometheus-proxy-deployment.yaml
+++ b/deploy/platform-reports/templates/prometheus-proxy-deployment.yaml
@@ -42,8 +42,8 @@ spec:
                 secretKeyRef:
                   name: platformservices-secret
                   key: cluster_token
-            - name: NP_AUTH_ACCESS_TOKEN_COOKIE_NAME
-              value: {{ .Values.platform.accessTokenCookieName }}
+            - name: NP_AUTH_ACCESS_TOKEN_COOKIE_NAMES
+              value: {{ .Values.platform.accessTokenCookieNames }}
             - name: NP_API_URL
               value: {{ .Values.platform.apiUrl }}
           {{- if .Values.prometheusProxy.resources }}

--- a/deploy/platform-reports/values.yaml
+++ b/deploy/platform-reports/values.yaml
@@ -11,7 +11,7 @@ objectStore:
   configMapName: thanos-object-storage-config
 
 platform:
-  accessTokenCookieName: sat
+  accessTokenCookieNames: sat,dat
 
 platformJobs:
   namespace: platform-jobs

--- a/platform_reports/config.py
+++ b/platform_reports/config.py
@@ -3,7 +3,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, Sequence
 
 from aiohttp.client import DEFAULT_TIMEOUT, ClientTimeout
 from yarl import URL
@@ -69,7 +69,7 @@ class PrometheusProxyConfig:
     platform_auth: PlatformServiceConfig
     platform_api: PlatformServiceConfig
     cluster_name: str
-    access_token_cookie_name: str
+    access_token_cookie_names: Sequence[str]
     timeout: ClientTimeout = DEFAULT_TIMEOUT
 
 
@@ -80,7 +80,7 @@ class GrafanaProxyConfig:
     platform_auth: PlatformServiceConfig
     platform_api: PlatformServiceConfig
     cluster_name: str
-    access_token_cookie_name: str
+    access_token_cookie_names: Sequence[str]
     timeout: ClientTimeout = DEFAULT_TIMEOUT
 
 
@@ -128,7 +128,9 @@ class EnvironConfigFactory:
             platform_auth=self._create_platform_auth(),
             platform_api=self._create_platform_api(),
             cluster_name=self._environ["NP_CLUSTER_NAME"],
-            access_token_cookie_name=self._environ["NP_AUTH_ACCESS_TOKEN_COOKIE_NAME"],
+            access_token_cookie_names=(
+                self._environ["NP_AUTH_ACCESS_TOKEN_COOKIE_NAMES"].split(",")
+            ),
         )
 
     def create_grafana_proxy(self) -> GrafanaProxyConfig:
@@ -138,7 +140,9 @@ class EnvironConfigFactory:
             platform_auth=self._create_platform_auth(),
             platform_api=self._create_platform_api(),
             cluster_name=self._environ["NP_CLUSTER_NAME"],
-            access_token_cookie_name=self._environ["NP_AUTH_ACCESS_TOKEN_COOKIE_NAME"],
+            access_token_cookie_names=(
+                self._environ["NP_AUTH_ACCESS_TOKEN_COOKIE_NAMES"].split(",")
+            ),
         )
 
     def _create_server(self) -> ServerConfig:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -206,7 +206,7 @@ def prometheus_proxy_config(
         platform_auth=platform_auth_config,
         platform_api=platform_api_config,
         cluster_name="default",
-        access_token_cookie_name="dat",
+        access_token_cookie_names=["dat"],
     )
 
 
@@ -232,7 +232,7 @@ def grafana_proxy_config(
         platform_auth=platform_auth_config,
         platform_api=platform_api_config,
         cluster_name="default",
-        access_token_cookie_name="dat",
+        access_token_cookie_names=["dat"],
     )
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -89,7 +89,7 @@ class TestEnvironConfigFactory:
     def test_create_prometheus_proxy_defaults(self) -> None:
         env = {
             "NP_CLUSTER_NAME": "default",
-            "NP_AUTH_ACCESS_TOKEN_COOKIE_NAME": "dat",
+            "NP_AUTH_ACCESS_TOKEN_COOKIE_NAMES": "sat,dat",
             "NP_PROMETHEUS_HOST": "prometheus",
             "NP_PROMETHEUS_PORT": "9090",
             "NP_AUTH_URL": "https://dev.neu.ro",
@@ -101,7 +101,7 @@ class TestEnvironConfigFactory:
 
         assert result == PrometheusProxyConfig(
             cluster_name="default",
-            access_token_cookie_name="dat",
+            access_token_cookie_names=["sat", "dat"],
             server=ServerConfig(),
             prometheus_server=ServerConfig(host="prometheus", port=9090),
             platform_auth=PlatformServiceConfig(
@@ -115,7 +115,7 @@ class TestEnvironConfigFactory:
     def test_create_prometheus_proxy_custom(self) -> None:
         env = {
             "NP_CLUSTER_NAME": "default",
-            "NP_AUTH_ACCESS_TOKEN_COOKIE_NAME": "dat",
+            "NP_AUTH_ACCESS_TOKEN_COOKIE_NAMES": "sat,dat",
             "NP_REPORTS_API_SCHEME": "https",
             "NP_REPORTS_API_HOST": "platform-reports",
             "NP_REPORTS_API_PORT": "80",
@@ -131,7 +131,7 @@ class TestEnvironConfigFactory:
 
         assert result == PrometheusProxyConfig(
             cluster_name="default",
-            access_token_cookie_name="dat",
+            access_token_cookie_names=["sat", "dat"],
             server=ServerConfig(scheme="https", host="platform-reports", port=80),
             prometheus_server=ServerConfig(
                 scheme="https", host="prometheus", port=9090
@@ -147,7 +147,7 @@ class TestEnvironConfigFactory:
     def test_create_grafana_proxy_defaults(self) -> None:
         env = {
             "NP_CLUSTER_NAME": "default",
-            "NP_AUTH_ACCESS_TOKEN_COOKIE_NAME": "dat",
+            "NP_AUTH_ACCESS_TOKEN_COOKIE_NAMES": "sat,dat",
             "NP_GRAFANA_HOST": "grafana",
             "NP_GRAFANA_PORT": "3000",
             "NP_AUTH_URL": "https://dev.neu.ro",
@@ -159,7 +159,7 @@ class TestEnvironConfigFactory:
 
         assert result == GrafanaProxyConfig(
             cluster_name="default",
-            access_token_cookie_name="dat",
+            access_token_cookie_names=["sat", "dat"],
             server=ServerConfig(),
             grafana_server=ServerConfig(host="grafana", port=3000),
             platform_auth=PlatformServiceConfig(
@@ -173,7 +173,7 @@ class TestEnvironConfigFactory:
     def test_create_grafana_proxy_custom(self) -> None:
         env = {
             "NP_CLUSTER_NAME": "default",
-            "NP_AUTH_ACCESS_TOKEN_COOKIE_NAME": "dat",
+            "NP_AUTH_ACCESS_TOKEN_COOKIE_NAMES": "sat,dat",
             "NP_REPORTS_API_SCHEME": "https",
             "NP_REPORTS_API_HOST": "platform-reports",
             "NP_REPORTS_API_PORT": "80",
@@ -189,7 +189,7 @@ class TestEnvironConfigFactory:
 
         assert result == GrafanaProxyConfig(
             cluster_name="default",
-            access_token_cookie_name="dat",
+            access_token_cookie_names=["sat", "dat"],
             server=ServerConfig(scheme="https", host="platform-reports", port=80),
             grafana_server=ServerConfig(scheme="https", host="grafana", port=3000),
             platform_auth=PlatformServiceConfig(


### PR DESCRIPTION
Service can be deployed by platform-operator in dev and staging environments. To support multiple environments we need to search for all possible places where access token can be.