### PR TITLE
fetch latest prometheus crds

### DIFF
--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -2,3 +2,4 @@ charts/
 tmpcharts/
 chart.lock
 requirements.lock
+prometheus-crds/

--- a/deploy/platform-reports/templates/prometheus-crds.yaml
+++ b/deploy/platform-reports/templates/prometheus-crds.yaml
@@ -1,0 +1,4 @@
+{{- range $path, $bytes := .Files.Glob "prometheus-crds/*.yaml" }}
+{{ $.Files.Get $path }}
+---
+{{- end }}

--- a/deploy/platform-reports/values.yaml
+++ b/deploy/platform-reports/values.yaml
@@ -194,6 +194,9 @@ prometheus-operator:
       - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
 
   prometheusOperator:
+    createCustomResource: false
+    cleanupCustomResource: true
+
     kubeletService:
       enabled: true
 
@@ -214,6 +217,8 @@ prometheus-operator:
           memory: "1Gi"
       storageSpec:
         volumeClaimTemplate:
+          metadata:
+            name: prometheus
           spec:
             accessModes: ["ReadWriteOnce"]
             resources:


### PR DESCRIPTION
`prometheus-operator` helm chart contains old Prometheus CRD's. Fetch the latest CRD's before deploying `platform-reports` helm chart.