### PR TITLE
disable pod price collector

### DIFF
--- a/platform_reports/api.py
+++ b/platform_reports/api.py
@@ -102,9 +102,6 @@ class MetricsHandler:
 
     async def handle(self, request: Request) -> Response:
         text = [self._get_node_price_per_hour_text()]
-        pod_prices_per_hour_text = self._get_pod_prices_per_hour_text()
-        if pod_prices_per_hour_text:
-            text.append(pod_prices_per_hour_text)
         pod_credits_per_hour_text = self._get_pod_credits_per_hour_text()
         if pod_credits_per_hour_text:
             text.append(pod_credits_per_hour_text)

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -51,10 +51,6 @@ kube_node_price_per_hour{node="minikube",currency="USD"} 0.0"""
 \# TYPE kube_node_price_per_hour gauge
 kube_node_price_per_hour\{node="minikube",currency="USD"\} 0(\.0+)?
 
-\# HELP kube_pod_price_per_hour The price of the pod per hour\.
-\# TYPE kube_pod_price_per_hour gauge
-(kube_pod_price_per_hour\{pod=".+",currency="USD"\} 0(\.0+)?\s*)+
-
 \# HELP kube_pod_credits_per_hour The credits of the pod per hour\.
 \# TYPE kube_pod_credits_per_hour gauge
 (kube_pod_credits_per_hour\{pod=".+"\} 0(\.0+)?\s*)+""",


### PR DESCRIPTION
https://sentry.io/organizations/neu-ro/issues/2400013328/events/75f52462e63142e992679db8ca39dc28/?project=5553359

According to [this comment](https://github.com/aio-libs/aiohttp/issues/3651#issuecomment-502087497) the recommendation is to reduce the number of parallel SSL handshakes. Pod prices are not used anymore in reports, collector can be disabled to see if it helps.