### PR TITLE
Iz/handle unknown jobs

### DIFF
--- a/platform_reports/metrics.py
+++ b/platform_reports/metrics.py
@@ -20,7 +20,12 @@ from google.oauth2.service_account import Credentials
 from googleapiclient import discovery
 from neuro_config_client import ConfigClient, EnergySchedule
 from neuro_logging import new_trace_cm, trace_cm
-from neuro_sdk import Client as ApiClient, JobDescription, ResourceNotFound
+from neuro_sdk import (
+    Client as ApiClient,
+    IllegalArgumentError,
+    JobDescription,
+    ResourceNotFound,
+)
 from yarl import URL
 
 from .kube_client import KubeClient
@@ -515,6 +520,9 @@ class PodCreditsCollector(Collector[Mapping[str, Decimal]]):
             try:
                 job = await self._api_client.jobs.status(pod_name)
             except ResourceNotFound:
+                logger.warning("Job %r not found", pod_name)
+                continue
+            except IllegalArgumentError:
                 logger.warning("Job %r not found", pod_name)
                 continue
             if not self._should_collect(job):

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ platforms = any
 install_requires =
     neuro-auth-client==22.6.1
     neuro-config-client==23.3.0
-    neuro-sdk==23.7.0
+    neuro-sdk==23.2.0
     neuro-logging==21.12.2
     aiohttp==3.8.4
     python-jose==3.3.0

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -35,9 +35,9 @@ from neuro_config_client import (
 )
 from neuro_sdk import (
     Client as ApiClient,
+    IllegalArgumentError,
     JobDescription,
     JobStatusHistory,
-    ResourceNotFound,
 )
 from yarl import URL
 
@@ -864,7 +864,7 @@ class TestPodCreditsCollector:
                 for job in jobs:
                     if job.id == id:
                         return job
-                raise ResourceNotFound(f"Job {id!r} not found")
+                raise IllegalArgumentError(f"Job {id!r} not found")
 
             result = mock.AsyncMock(spec=ApiClient)
             result.jobs = mock.AsyncMock()


### PR DESCRIPTION
after postgres backup restore we lost some data in db, there are some jobs in k8s but no such jobs in postgres.
currently platform-api returns 400 if job is not found and metrics exporter crashes during startup.