### PR TITLE
feat(external-secrets): migrate platform helm charts to external secrets

### DIFF
--- a/charts/platform-reports/Chart.yaml
+++ b/charts/platform-reports/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: platform-reports
 description: A Helm chart for platform-reports service
-version: 1.0.0
+version: 1.1.0
 appVersion: 1.0.0
 kubeVersion: ">=1.21.0-0"
 dependencies:

--- a/charts/platform-reports/templates/externalSecret.yaml
+++ b/charts/platform-reports/templates/externalSecret.yaml
@@ -1,0 +1,30 @@
+{{- range .Values.externalSecrets }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .name | quote }}
+  labels: {{ include "platformAdmin.labels.standard" $ | nindent 4 }}
+    service: platform-admin
+spec:
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: {{ .secretStoreName | default "default-secret-store" | quote }}
+    kind: {{ .secretStoreKind | default "ClusterSecretStore" }}
+  target:
+    name: {{ .name | quote }}
+    creationPolicy: "Owner"
+    template:
+      metadata:
+        labels: {{ include "platformAdmin.labels.standard" $ | nindent 10 }}
+          service: platform-admin
+        annotations:
+          reloader.stakater.com/match: "true"
+  data:
+    {{- range $key, $ref := .data }}
+    - secretKey: {{ $key | quote }} #target K8s secret key
+      remoteRef:
+        key: {{ $ref.key | quote }} #Remote secret mount key, e.g.. vault
+        property: {{ $ref.property | quote }} #Remote secret key, e.g.. platform-admin-dsn
+    {{- end }}
+{{- end }}

--- a/charts/platform-reports/templates/externalSecret.yaml
+++ b/charts/platform-reports/templates/externalSecret.yaml
@@ -4,8 +4,8 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .name | quote }}
-  labels: {{ include "platformAdmin.labels.standard" $ | nindent 4 }}
-    service: platform-admin
+  labels: {{ include "platformReports.labels.standard" $ | nindent 4 }}
+    service: platform-reports
 spec:
   refreshInterval: "15s"
   secretStoreRef:
@@ -16,8 +16,8 @@ spec:
     creationPolicy: "Owner"
     template:
       metadata:
-        labels: {{ include "platformAdmin.labels.standard" $ | nindent 10 }}
-          service: platform-admin
+        labels: {{ include "platformReports.labels.standard" $ | nindent 10 }}
+          service: platform-reports
         annotations:
           reloader.stakater.com/match: "true"
   data:

--- a/charts/platform-reports/values.yaml
+++ b/charts/platform-reports/values.yaml
@@ -25,17 +25,17 @@ imagePullSecrets: []
 
 secrets: []
 
-externalSecrets:
-  - name: platform-admin-secret
-    secretStoreName: vault-backend
-    secretStoreKind: ClusterSecretStore
-    data:
-      DATABASE_URL:
-        key: kv-v2/platform
-        property: DATABASE_URL
-      API_KEY:
-        key: kv-v2/platform
-        property: API_KEY
+externalSecrets: []
+  # - name: platform-admin-secret
+  #   secretStoreName: vault-backend
+  #   secretStoreKind: ClusterSecretStore
+  #   data:
+  #     DATABASE_URL:
+  #       key: kv-v2/platform
+  #       property: DATABASE_URL
+  #     API_KEY:
+  #       key: kv-v2/platform
+  #       property: API_KEY
 
 metricsApi:
   replicas: 2

--- a/charts/platform-reports/values.yaml
+++ b/charts/platform-reports/values.yaml
@@ -25,6 +25,18 @@ imagePullSecrets: []
 
 secrets: []
 
+externalSecrets:
+  - name: platform-admin-secret
+    secretStoreName: vault-backend
+    secretStoreKind: ClusterSecretStore
+    data:
+      DATABASE_URL:
+        key: kv-v2/platform
+        property: DATABASE_URL
+      API_KEY:
+        key: kv-v2/platform
+        property: API_KEY
+
 metricsApi:
   replicas: 2
   nameOverride: ""


### PR DESCRIPTION
This PR migrates the platform helm chart to use external secrets and bumps the chart minor version.